### PR TITLE
Reformat blog post title and datestamp/byline

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,12 +2,10 @@
 layout: blank
 ---
 
-	     <header>
-			<p class="kicker">{{ page.date | date: "%B %-d, %Y" }}</p>
-			<h1>{{ page.title }}</h1>
-            <p class="byline">{% include author.html %}</p>
-		 </header>
+<h1>{{ page.title }}</h1>
+<p>{{ page.date | date: "%B %-d, %Y" }}</p>
+<p>{% include author.html %}</p>
 
-      {{ content }}
+{{ content }}
 
-      {% include author-info.html %}
+{% include author-info.html %}


### PR DESCRIPTION
This still leaves the date and author name unstyled, so you may want to add some CSS & classes