### PR TITLE
Version history links

### DIFF
--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -79,15 +79,6 @@ menu-lang:
     title: '[en]'
     link: /
 
-and:
-   en: and
-   es: y
-by:
-   en: by
-   es: por
-reviewed:
-   en: reviewed
-   es: revisado
 footer:
   ph-released:
     en: <em>The Programming Historian</em> is released under the

--- a/_data/snippets.yml
+++ b/_data/snippets.yml
@@ -87,3 +87,23 @@ by:
 reviewed:
    en: reviewed
    es: revisado
+footer:
+  ph-released:
+    en: <em>The Programming Historian</em> is released under the
+    es: <em>The Programming Historian en español</em>
+  license:
+    en: license
+    es: licencia
+  gh-hosted:
+    en: Hosted on GitHub
+    es: Alojado en GitHub
+  rev-history:
+    en: See change history
+    es: Versiones anteriores
+  last-updated:
+    en: Last updated
+    es: Última actualización el
+  suggestion:
+    en: Make a suggestion
+    es: Envíanos tus comentarios
+    

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -22,7 +22,7 @@
 
   <div class="col-sm-3">
   <i class="fa fa-history" aria-hidden="true"></i>
-  <a href="https://github.com/programminghistorian/jekyll/commits/gh-pages/">See change history</a>
+  <a href="https://github.com/programminghistorian/jekyll/commits/gh-pages/{{ page.path }}">See change history</a>
   </div>
 
   <div class="col-sm-3">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 <footer role="contentinfo">
 
-{% if page.lang == "en" %}
 <div class="container-fluid">
+{% if page.lang == "en" %}
 
 <div class="row">
   <div class="col-sm-12 footer-head">
@@ -31,23 +31,41 @@
   </div>
 
 </div>
+
+{% elsif page.lang == "es" %}
+
+<div class="row">
+  <div class="col-sm-12 footer-head">
+    <em>The Programming Historian</em> es distribuido bajo una <a href="http://creativecommons.org/licenses/by/2.0/" rel="license">CC-BY</a> licencia.</p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-sm-3">
+    <i class="fa fa-github" aria-hidden="true"></i>
+    <a href="https://github.com/programminghistorian/jekyll">Alojado en GitHub</a>
+  </div>
+
+  <div class="col-sm-3">
+  <i class="fa fa-calendar" aria-hidden="true"></i>
+  Última actualización el {{ site.time | date_to_long_string }}
+  </div>
+
+  <div class="col-sm-3">
+  <i class="fa fa-history" aria-hidden="true"></i>
+  <a href="https://github.com/programminghistorian/jekyll/commits/gh-pages/{{ page.path }}">Versiones anteriores</a>
+  </div>
+
+  <div class="col-sm-3">
+  <i class="fa fa-bolt" aria-hidden="true"></i>
+  <a href="{{site.baseurl}}/es/retroalimentacion">Envíanos tus comentarios</a>
+  </div>
+
 </div>
 
 {% endif %}
+</div>
 
-{% if page.lang == "es" %}
-
-<p><em>The Programming Historian</em> es distribuido bajo una <a href="http://creativecommons.org/licenses/by/2.0/" rel="license">licencia CC-BY</a>.</p>
-<p>El proyecto es publicado por el <em>Comité Editorial de Programming Historian</em>, y apareció por primera vez en julio de 2012. Última actualización: {{ site.time | date_to_long_string }}.</p>
-<p class="github">
-
-        <a href="https://github.com/programminghistorian/jekyll">Alojado en GitHub <img src="/images/GitHub-Mark-32px.png" title="GitHub logo"></a>
-		<a href="https://github.com/programminghistorian/jekyll/commits/gh-pages/{{ page.path }}">Versiones anteriores</a>&nbsp;&#183;&nbsp;
-		<a href="http://programminghistorian.org/es/retroalimentacion">Envíanos tus comentarios</a>
-
-</p>
-
-{% endif %}
 </footer>
 
 {% include analytics.html %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,69 +1,35 @@
 <footer role="contentinfo">
 
 <div class="container-fluid">
-{% if page.lang == "en" %}
 
 <div class="row">
   <div class="col-sm-12 footer-head">
-    <em>Programming Historian</em> is released under the <a href="http://creativecommons.org/licenses/by/2.0/" rel="license">CC-BY</a> license.</p>
+    {{ site.data.snippets.footer.ph-released[page.lang] }} <a href="http://creativecommons.org/licenses/by/2.0/" rel="license">CC-BY</a> {{ site.data.snippets.footer.license[page.lang] }}.</p>
   </div>
 </div>
 
 <div class="row">
   <div class="col-sm-3">
     <i class="fa fa-github" aria-hidden="true"></i>
-    <a href="https://github.com/programminghistorian/jekyll">Hosted on GitHub</a>
+    <a href="https://github.com/programminghistorian/jekyll">{{ site.data.snippets.footer.gh-hosted[page.lang] }}</a>
   </div>
 
   <div class="col-sm-3">
   <i class="fa fa-calendar" aria-hidden="true"></i>
-  Last updated {{ site.time | date_to_long_string }}
+  {{ site.data.snippets.footer.last-updated[page.lang] }} {{ site.time | date_to_long_string }}
   </div>
 
   <div class="col-sm-3">
   <i class="fa fa-history" aria-hidden="true"></i>
-  <a href="https://github.com/programminghistorian/jekyll/commits/gh-pages/{{ page.path }}">See change history</a>
+  <a href="https://github.com/programminghistorian/jekyll/commits/gh-pages/{{ page.path }}">{{ site.data.snippets.footer.rev-history[page.lang] }}</a>
   </div>
 
   <div class="col-sm-3">
   <i class="fa fa-bolt" aria-hidden="true"></i>
-  <a href="{{site.baseurl}}/feedback">Make a suggestion!</a>
+  <a href="{{site.baseurl}}{{ site.data.snippets.menu-contribute-feedback[page.lang].link }}">{{ site.data.snippets.footer.suggestion[page.lang] }}</a>
   </div>
 
-</div>
-
-{% elsif page.lang == "es" %}
-
-<div class="row">
-  <div class="col-sm-12 footer-head">
-    <em>The Programming Historian</em> es distribuido bajo una <a href="http://creativecommons.org/licenses/by/2.0/" rel="license">CC-BY</a> licencia.</p>
   </div>
-</div>
-
-<div class="row">
-  <div class="col-sm-3">
-    <i class="fa fa-github" aria-hidden="true"></i>
-    <a href="https://github.com/programminghistorian/jekyll">Alojado en GitHub</a>
-  </div>
-
-  <div class="col-sm-3">
-  <i class="fa fa-calendar" aria-hidden="true"></i>
-  Última actualización el {{ site.time | date_to_long_string }}
-  </div>
-
-  <div class="col-sm-3">
-  <i class="fa fa-history" aria-hidden="true"></i>
-  <a href="https://github.com/programminghistorian/jekyll/commits/gh-pages/{{ page.path }}">Versiones anteriores</a>
-  </div>
-
-  <div class="col-sm-3">
-  <i class="fa fa-bolt" aria-hidden="true"></i>
-  <a href="{{site.baseurl}}/es/retroalimentacion">Envíanos tus comentarios</a>
-  </div>
-
-</div>
-
-{% endif %}
 </div>
 
 </footer>


### PR DESCRIPTION
This implements bilingual site footer links and text.

Note: after working this up, I saw you intend to link to "version history" in the lesson header. I think that makes sense, but I'd suggest doing that _in addition_ to having them in the footer, as all pages on the site, not just lessons, have a version history.

re: https://github.com/programminghistorian/jekyll/issues/446